### PR TITLE
Add Instructions tab to UI

### DIFF
--- a/about_page.py
+++ b/about_page.py
@@ -30,6 +30,8 @@ def render_about_page():
     The application is designed with a focus on modularity, efficiency, and empowering users to derive
     actionable intelligence from complex information landscapes.
 
+    For a practical guide to each feature, see the **Instructions** tab.
+
     *Disclaimer: This application is currently a demonstration and development prototype. It should not be
     used for making real-world legal or financial decisions without independent verification by qualified
     professionals. All data processing and AI outputs are subject to the inherent limitations of the

--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ import ch_pipeline
 import app_utils
 import ai_utils
 from about_page import render_about_page # Changed from show_about_page
+from instructions_page import render_instructions_page
 try:
     import group_structure_utils
     GROUP_STRUCTURE_AVAILABLE = True
@@ -142,6 +143,7 @@ try:
         extract_text_from_uploaded_file
     )
     from about_page import render_about_page
+    from instructions_page import render_instructions_page
     from ch_pipeline import run_batch_company_analysis
     from ai_utils import get_improved_prompt # Added import
     # from ai_utils import _gemini_generate_content_with_retry_and_tokens # Not directly used in app.py typically
@@ -491,18 +493,20 @@ st.markdown(f"## 🏛️ Strategic Counsel: {st.session_state.current_topic}")
 
 # Define tabs based on what functionality is available
 if 'GROUP_STRUCTURE_AVAILABLE' in globals() and GROUP_STRUCTURE_AVAILABLE:
-    tab_consult, tab_ch_analysis, tab_group_structure, tab_about_rendered = st.tabs([
-        "💬 Consult Counsel", 
-        "🇬🇧 Companies House Analysis", 
+    tab_consult, tab_ch_analysis, tab_group_structure, tab_about_rendered, tab_instructions = st.tabs([
+        "💬 Consult Counsel",
+        "🇬🇧 Companies House Analysis",
         "🕸️ Company Group Structure",  # Include group structure tab
-        "ℹ️ About"
+        "ℹ️ About",
+        "📖 Instructions"
     ])
 else:
     # Fall back to three tabs if group structure not available
-    tab_consult, tab_ch_analysis, tab_about_rendered = st.tabs([
-        "💬 Consult Counsel", 
-        "🇬🇧 Companies House Analysis", 
-        "ℹ️ About"
+    tab_consult, tab_ch_analysis, tab_about_rendered, tab_instructions = st.tabs([
+        "💬 Consult Counsel",
+        "🇬🇧 Companies House Analysis",
+        "ℹ️ About",
+        "📖 Instructions"
     ])
     # Create a placeholder for tab_group_structure to avoid errors later in the code
     class PlaceholderTab:
@@ -1103,5 +1107,8 @@ with tab_group_structure:
 
 with tab_about_rendered:
     render_about_page()
+
+with tab_instructions:
+    render_instructions_page()
 
 # --- End of Main App Area UI (Using Tabs) ---

--- a/instructions_page.py
+++ b/instructions_page.py
@@ -1,0 +1,29 @@
+import streamlit as st
+
+"""Instructions page for Strategic Counsel"""
+
+
+def render_instructions_page():
+    """Render step-by-step usage instructions."""
+    st.markdown("## 📖 Instructions: Using Strategic Counsel")
+    st.markdown(
+        """
+        Follow these guidelines to make the most of each feature:
+        1. **Set your Matter / Topic ID** in the sidebar. This keeps workspaces separate.
+        2. **Consult Counsel** – Draft or analyse documents:
+           - Enter your instruction in the text area.
+           - Optionally click **Suggest Improved Prompt** to refine it.
+           - Use the sidebar to inject previous digests, memories, uploads or web links.
+           - Submit to receive AI-generated output and optionally export to DOCX or update your digest.
+        3. **Companies House Analysis** – Summarise UK filings:
+           - Enter company numbers and select year range and document categories.
+           - Run the analysis; review and download summaries or CSV results.
+           - Tick summaries you want to inject back into **Consult Counsel**.
+        4. **Company Group Structure** (if enabled):
+           - Provide a company number and follow the step buttons to fetch profiles, parent data and subsidiary details.
+        5. **About** – Overview of the system and environment details.
+        
+        For best results keep instructions concise and load only the most relevant context.
+        """
+    )
+


### PR DESCRIPTION
## Summary
- add new `instructions_page` module and include concise usage guide
- update About page with link to instructions tab
- integrate Instructions tab into main app

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*