### PR TITLE
Enable latest AI model defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -409,9 +409,13 @@ with st.sidebar:
 
                     if error_msg: title, summary = f"Error: {src_id[:40]}...", error_msg
                     elif not raw_content or not raw_content.strip(): title, summary = f"Empty: {src_id[:40]}...", "No text content found or extracted."
-                    else: # Successfully got raw content
-                        # Use a cost-effective model for these quick summaries
-                        title, summary = summarise_with_title(raw_content, "gpt-4o-mini", st.session_state.current_topic, PROTO_TEXT)
+                    else:  # Successfully got raw content
+                        # Use the configured default model for quick summaries
+                        title, summary = summarise_with_title(
+                            raw_content,
+                            config.OPENAI_MODEL_DEFAULT,
+                            st.session_state.current_topic,
+                        )
 
                     if "Error" not in title and "Empty" not in title: # Cache if successfully processed
                         try: summary_cache_file.write_text(json.dumps({"t":title,"s":summary,"src":src_id}),encoding="utf-8")

--- a/app_utils.py
+++ b/app_utils.py
@@ -94,13 +94,13 @@ def _word_cap(word_count: int) -> int:
 
 def summarise_with_title(
     text: str,
-    model_name_selected: str, # This parameter seems unused as the function hardcodes "gpt-4o-mini"
-    topic: str, 
+    model_name_selected: str,
+    topic: str,
 ) -> Tuple[str, str]:
     """
     Generates a short title and summary for UI display of uploaded documents.
-    Uses a cost-effective OpenAI model for this task.
-    Uses LOADED_PROTO_TEXT from config.
+    Uses the provided OpenAI model (or the configured default) for this task.
+    Utilises LOADED_PROTO_TEXT from config.
     """
     if not text or not text.strip():
         return "Empty Content", "No text was provided for summarization."
@@ -109,7 +109,7 @@ def summarise_with_title(
     summary_word_cap = _word_cap(word_count)
     text_to_summarise = text[:15000] 
     max_tokens_for_response = int(summary_word_cap * 2.0) 
-    openai_model_for_this_task = "gpt-4o-mini" 
+    openai_model_for_this_task = model_name_selected or config.OPENAI_MODEL_DEFAULT
     openai_client = get_openai_client()
 
     if not openai_client:

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -379,7 +379,7 @@ class CompanyHouseDocumentPipeline:
                     summary_text, _, _ = gpt_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o"  # type: ignore
+                        model_to_use=config.OPENAI_MODEL_DEFAULT  # type: ignore
                     )
                 else:
                     logger.warning(f"No AI summarization client (Gemini/OpenAI) available/configured for {self.company_number} (Year {year}).")

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -477,7 +477,7 @@ def run_batch_company_analysis(
                         summarizer_func_to_call = gemini_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using Gemini ('{ai_model_to_use_for_summary}') for CH summary.")
                     elif openai_key_ok:
-                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o"  # type: ignore
+                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT  # type: ignore
                         summarizer_func_to_call = gpt_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using OpenAI ('{ai_model_to_use_for_summary}') for CH summary (Gemini unavailable).")
                     

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -37,8 +37,8 @@ except ImportError:
     MIN_MEANINGFUL_TEXT_LEN = 200
     # Define a dummy config object or attributes if other parts of the code expect config.X
     class DummyConfig:
-        GEMINI_MODEL_DEFAULT = "gemini-1.5-pro-latest" # Example
-        OPENAI_MODEL_DEFAULT = "gpt-4o-mini" # Example
+        GEMINI_MODEL_DEFAULT = "gemini-1.5-pro-latest"  # Example
+        OPENAI_MODEL_DEFAULT = "gpt-4o"  # Example uses latest OpenAI model
         GEMINI_API_KEY = None
         OPENAI_API_KEY = None
     config = DummyConfig() # type: ignore
@@ -379,7 +379,7 @@ class CompanyHouseDocumentPipeline:
                     summary_text, _, _ = gpt_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o-mini" # type: ignore
+                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o"  # type: ignore
                     )
                 else:
                     logger.warning(f"No AI summarization client (Gemini/OpenAI) available/configured for {self.company_number} (Year {year}).")
@@ -477,7 +477,7 @@ def run_batch_company_analysis(
                         summarizer_func_to_call = gemini_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using Gemini ('{ai_model_to_use_for_summary}') for CH summary.")
                     elif openai_key_ok:
-                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o-mini" # type: ignore
+                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o"  # type: ignore
                         summarizer_func_to_call = gpt_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using OpenAI ('{ai_model_to_use_for_summary}') for CH summary (Gemini unavailable).")
                     

--- a/config.py
+++ b/config.py
@@ -55,9 +55,16 @@ AWS_REGION_DEFAULT = os.getenv("AWS_DEFAULT_REGION", "eu-west-2")
 S3_TEXTRACT_BUCKET = os.getenv("S3_TEXTRACT_BUCKET") # For Textract
 
 # --- Model Configuration ---
-OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
-GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-1.5-pro-latest") # More specific name
-GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv("GEMINI_MODEL_FOR_PROTOCOL_CHECK", "gemini-1.5-flash-latest") # Model for protocol check
+# Defaults to the most capable currently available models. Users can
+# override via environment variables if desired.
+OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4o")
+GEMINI_MODEL_DEFAULT = os.getenv(
+    "GEMINI_MODEL_FOR_SUMMARIES",
+    "gemini-1.5-pro-latest",
+)  # More specific name
+GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv(
+    "GEMINI_MODEL_FOR_PROTOCOL_CHECK", "gemini-1.5-flash-latest"
+)  # Model for protocol check
 
 # --- Application Constants ---
 MIN_MEANINGFUL_TEXT_LEN = 200


### PR DESCRIPTION
## Summary
- default to `gpt-4o` OpenAI model
- let `summarise_with_title` use the chosen model
- use configured default model for quick summaries
- update fallbacks in `ch_pipeline`

## Testing
- `python -m py_compile app.py ai_utils.py app_utils.py config.py ch_pipeline.py`