### PR TITLE
Update defaults to GPT-4.1 and Gemini-3.5

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,14 +168,12 @@ for rel_p in REQUIRED_DIRS_REL:
     except OSError as e_mkdir: st.error(f"Fatal Error creating directory {abs_p.name}: {e_mkdir}"); st.stop()
 
 MODEL_PRICES_PER_1K_TOKENS_GBP: Dict[str, float] = {
-    "gpt-4o": 0.0040, "gpt-4-turbo": 0.0080, "gpt-3.5-turbo": 0.0004, "gpt-4o-mini": 0.00012,
-    config.GEMINI_MODEL_DEFAULT: 0.0028,
-    "gemini-1.5-pro-latest": 0.0028, # Ensure this matches config.GEMINI_MODEL_DEFAULT if it's the one
-    "gemini-1.5-flash-latest": 0.00028
+    "gpt-4.1": 0.0080,
+    "gemini-3.5": 0.0028,
 }
 MODEL_ENERGY_WH_PER_1K_TOKENS: Dict[str, float] = {
-    "gpt-4o": 0.15, "gpt-4-turbo": 0.4, "gpt-3.5-turbo": 0.04, "gpt-4o-mini": 0.02,
-    config.GEMINI_MODEL_DEFAULT: 0.2, "gemini-1.5-pro-latest": 0.2, "gemini-1.5-flash-latest": 0.05
+    "gpt-4.1": 0.4,
+    "gemini-3.5": 0.2,
 }
 KETTLE_WH: int = 360
 
@@ -222,7 +220,7 @@ def init_session_state():
         "latest_digest_content": "",
         "document_processing_complete": True, "ch_last_digest_path": None, "ch_last_df": None,
         "ch_last_narrative": None, "ch_last_batch_metrics": {},
-        "consult_digest_model": config.OPENAI_MODEL_DEFAULT if 'config' in globals() and hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o", # Fallback if config not loaded
+        "consult_digest_model": config.OPENAI_MODEL_DEFAULT if 'config' in globals() and hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1", # Fallback if config not loaded
         "ch_analysis_summaries_for_injection": [], # List of (company_id, title_for_list, summary_text)
         
         # For "Improve Prompt" in Consult Counsel
@@ -446,7 +444,7 @@ with st.sidebar:
                         elif not raw_content or not raw_content.strip(): title, summary = f"Empty: {src_id[:40]}...", "No text content found or extracted."
                         else: # Successfully got raw content
                             # Use a cost-effective model for these quick summaries
-                            title, summary = summarise_with_title(raw_content, "gpt-4o-mini", st.session_state.current_topic, PROTO_TEXT)
+                            title, summary = summarise_with_title(raw_content, config.OPENAI_MODEL_DEFAULT, st.session_state.current_topic, PROTO_TEXT)
     
                         if "Error" not in title and "Empty" not in title: # Cache if successfully processed
                             try: summary_cache_file.write_text(json.dumps({"t":title,"s":summary,"src":src_id}),encoding="utf-8")

--- a/app_utils.py
+++ b/app_utils.py
@@ -52,12 +52,13 @@ except ImportError:
 
 # --- Imports from project ---
 from config import (
-    get_openai_client, 
-    get_ch_session, 
-    PROTO_TEXT_FALLBACK, 
-    LOADED_PROTO_TEXT, 
+    get_openai_client,
+    get_ch_session,
+    PROTO_TEXT_FALLBACK,
+    LOADED_PROTO_TEXT,
     # logger is already imported/handled above
-    MIN_MEANINGFUL_TEXT_LEN 
+    MIN_MEANINGFUL_TEXT_LEN,
+    OPENAI_MODEL_DEFAULT,
 )
 
 # --- Optional AWS SDK imports ---
@@ -96,7 +97,7 @@ def _word_cap(word_count: int) -> int:
 
 def summarise_with_title(
     text: str,
-    model_name_selected: str, # This parameter seems unused as the function hardcodes "gpt-4o-mini"
+    model_name_selected: str,  # Currently ignored; OPENAI_MODEL_DEFAULT is used
     topic: str, 
 ) -> Tuple[str, str]:
     """
@@ -110,8 +111,8 @@ def summarise_with_title(
     word_count = len(text.split())
     summary_word_cap = _word_cap(word_count)
     text_to_summarise = text[:15000] 
-    max_tokens_for_response = int(summary_word_cap * 2.0) 
-    openai_model_for_this_task = "gpt-4o-mini" 
+    max_tokens_for_response = int(summary_word_cap * 2.0)
+    openai_model_for_this_task = OPENAI_MODEL_DEFAULT
     openai_client = get_openai_client()
 
     if not openai_client:

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -375,14 +375,14 @@ class CompanyHouseDocumentPipeline:
                     summary_text, _, _ = gemini_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_name=config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-1.5-pro-latest" # type: ignore
+                        model_name=config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-3.5" # type: ignore
                     )
                 elif openai and openai_key_present: 
                     logger.info(f"Summarizing {len(texts_for_year)} docs for {self.company_number} (Year {year}) using OpenAI.")
                     summary_text, _, _ = gpt_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o-mini" # type: ignore
+                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1" # type: ignore
                     )
                 else:
                     logger.warning(f"No AI summarization client (Gemini/OpenAI) available/configured for {self.company_number} (Year {year}).")
@@ -476,11 +476,11 @@ def run_batch_company_analysis(
                     openai_key_ok = openai and hasattr(config, 'OPENAI_API_KEY') and config.OPENAI_API_KEY # type: ignore
 
                     if gemini_key_ok:
-                        ai_model_to_use_for_summary = config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-1.5-pro-latest" # type: ignore
+                        ai_model_to_use_for_summary = config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-3.5" # type: ignore
                         summarizer_func_to_call = gemini_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using Gemini ('{ai_model_to_use_for_summary}') for CH summary.")
                     elif openai_key_ok:
-                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o-mini" # type: ignore
+                        ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1" # type: ignore
                         summarizer_func_to_call = gpt_summarise_ch_docs
                         logger.debug(f"Batch Run {run_id} ({company_no}): Using OpenAI ('{ai_model_to_use_for_summary}') for CH summary (Gemini unavailable).")
                     

--- a/config.py
+++ b/config.py
@@ -55,8 +55,8 @@ AWS_REGION_DEFAULT = os.getenv("AWS_DEFAULT_REGION", "eu-west-2")
 S3_TEXTRACT_BUCKET = os.getenv("S3_TEXTRACT_BUCKET") # For Textract
 
 # --- Model Configuration ---
-OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
-GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-1.5-pro-latest") # More specific name
+OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4.1")
+GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-3.5") # More specific name
 GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv("GEMINI_MODEL_FOR_PROTOCOL_CHECK", "gemini-1.5-flash-latest") # Model for protocol check
 
 # --- Application Constants ---


### PR DESCRIPTION
## Summary
- reduce available model list to `gpt-4.1` and `gemini-3.5`
- change config defaults for OpenAI and Gemini models
- update hardcoded model names in `app_utils` and `ch_pipeline`
- ensure quick summaries use the updated default model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_textract_integration.py`