### PR TITLE
Enable parallel Textract OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ The application loads configuration from a `.env` file or the host environment. 
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials used when AWS Textract OCR is enabled.
 - `AWS_DEFAULT_REGION` – AWS region (for Textract), for example `eu-west-2`.
 - `S3_TEXTRACT_BUCKET` – S3 bucket name used to temporarily store PDFs when sending them to Textract.
+- `MAX_TEXTRACT_WORKERS` – number of concurrent Textract OCR workers (default `4`).
 
 Other optional variables (such as logging level or API retry options) can be defined as needed. See `config.py` for the full list.
 
 ## Enabling OCR with AWS Textract
 
 Within the **Group Structure** tab of the application there is a checkbox labelled **"Use AWS Textract for PDF OCR"**. When checked, the system attempts to initialise AWS Textract using the credentials above. Scanned or image-based PDFs from Companies House will then be sent to Textract for optical character recognition before analysis.
+
+Textract calls can now run in parallel to speed up large batches. The default maximum number of concurrent OCR workers is controlled by the `MAX_TEXTRACT_WORKERS` environment variable (default `4`). Reduce this value if you hit AWS rate limits.
 
 Without OCR, many Companies House PDF filings cannot be parsed, meaning group-structure analysis may miss critical information contained in scanned documents. If OCR fails to initialise or the checkbox is left unchecked, only PDFs containing embedded text are analysed.
 

--- a/app.py
+++ b/app.py
@@ -947,7 +947,8 @@ with tab_ch_analysis:
                             filter_keywords_str=ch_keywords_for_filter,
                             base_scratch_dir=APP_BASE_PATH / "temp_ch_runs",
                             keep_days=7,
-                            use_textract_ocr=(config.CH_PIPELINE_TEXTRACT_FLAG if hasattr(config, 'CH_PIPELINE_TEXTRACT_FLAG') else False)
+                            use_textract_ocr=(config.CH_PIPELINE_TEXTRACT_FLAG if hasattr(config, 'CH_PIPELINE_TEXTRACT_FLAG') else False),
+                            textract_workers=config.MAX_TEXTRACT_WORKERS,
                         )
 
                         # Path for the DOCX report download button

--- a/config.py
+++ b/config.py
@@ -62,6 +62,7 @@ GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv("GEMINI_MODEL_FOR_PROTOCOL_CHECK", "
 # --- Application Constants ---
 MIN_MEANINGFUL_TEXT_LEN = 200
 MAX_DOCS_TO_PROCESS_PER_COMPANY = int(os.getenv("MAX_DOCS_PER_COMPANY_PIPELINE", "20"))
+MAX_TEXTRACT_WORKERS = int(os.getenv("MAX_TEXTRACT_WORKERS", "4"))
 CH_API_BASE_URL = "https://api.company-information.service.gov.uk"
 CH_DOCUMENT_API_BASE_URL = "https://document-api.company-information.service.gov.uk"
 

--- a/test_parallel_ocr.py
+++ b/test_parallel_ocr.py
@@ -1,0 +1,77 @@
+import unittest
+import time
+from pathlib import Path
+import tempfile
+from unittest.mock import patch
+import importlib.util
+import sys
+import types
+
+class TestParallelOCR(unittest.TestCase):
+    def test_parallel_textract_processing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs = []
+            for i in range(3):
+                p = Path(tmpdir) / f"doc{i}.pdf"
+                content = f"text{i}".encode()
+                p.write_bytes(content)
+                docs.append({
+                    "local_path": p,
+                    "saved_content_type": "pdf",
+                    "original_metadata": {"transaction_id": f"tx{i}"}
+                })
+
+            sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+            openai_mod = types.ModuleType('openai'); openai_mod.OpenAI = object
+            sys.modules.setdefault('openai', openai_mod)
+            requests_mod = types.ModuleType('requests'); requests_mod.Session = object
+            sys.modules.setdefault('requests', requests_mod)
+            sys.modules.setdefault('google', types.ModuleType('google'))
+            sys.modules.setdefault('google.generativeai', types.ModuleType('google.generativeai'))
+            sys.modules.setdefault('bs4', types.ModuleType('bs4'))
+            pdf_mod = types.ModuleType('PyPDF2'); pdf_mod.errors = types.SimpleNamespace(PdfReadWarning=Warning)
+            sys.modules.setdefault('PyPDF2', pdf_mod)
+            sys.modules.setdefault('PyPDF2.errors', pdf_mod.errors)
+            text_ex_mod = types.ModuleType('text_extraction_utils')
+            text_ex_mod.extract_text_from_document = lambda *a, **k: ("",0,None)
+            text_ex_mod.OCRHandlerType = object
+            sys.modules.setdefault('text_extraction_utils', text_ex_mod)
+            ai_utils_mod = types.ModuleType('ai_utils')
+            ai_utils_mod.gpt_summarise_ch_docs = lambda *a, **k: ""
+            ai_utils_mod.gemini_summarise_ch_docs = lambda *a, **k: ""
+            sys.modules.setdefault('ai_utils', ai_utils_mod)
+
+            spec = importlib.util.spec_from_file_location('ch_pipeline', Path(__file__).resolve().parent / 'ch_pipeline.py')
+            ch_pipeline_mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(ch_pipeline_mod)
+
+            pipeline = ch_pipeline_mod.CompanyHouseDocumentPipeline(
+                company_number="12345678",
+                ch_api_key="dummy",
+                use_textract_for_ocr_if_available=True,
+            )
+
+            def fake_ocr(pdf_bytes, log_id):
+                time.sleep(0.2)
+                return pdf_bytes.decode(), 1, None
+
+            def fake_extract(*args, **kwargs):
+                ocr_handler = kwargs.get("ocr_handler")
+                pdf_bytes = kwargs.get("doc_content_input")
+                company_no = kwargs.get("company_no_for_logging", "n")
+                return ocr_handler(pdf_bytes, company_no)
+
+            with patch.object(ch_pipeline_mod, "perform_textract_ocr", side_effect=fake_ocr), \
+                 patch.object(ch_pipeline_mod, "extract_text_from_document", side_effect=fake_extract):
+                start = time.time()
+                results = pipeline._process_documents(docs, max_workers=3)
+                duration = time.time() - start
+
+            self.assertLess(duration, 0.5)
+            for idx, res in enumerate(results):
+                self.assertEqual(res["extracted_text"], f"text{idx}")
+                self.assertEqual(res["num_pages_ocrd"], 1)
+                self.assertIsNone(res["extraction_error"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add configurable `MAX_TEXTRACT_WORKERS` setting
- process PDFs concurrently in `ch_pipeline`
- allow batch analysis to use multiple OCR workers
- document new parallel OCR option in README
- test parallel processing with mocked Textract

## Testing
- `python test_textract_integration.py -v`
- `python test_parallel_ocr.py -v`
