### PR TITLE
Update default Gemini model

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,11 +169,11 @@ for rel_p in REQUIRED_DIRS_REL:
 
 MODEL_PRICES_PER_1K_TOKENS_GBP: Dict[str, float] = {
     "gpt-4.1": 0.0080,
-    "gemini-3.5": 0.0028,
+    config.GEMINI_MODEL_DEFAULT: 0.0028,
 }
 MODEL_ENERGY_WH_PER_1K_TOKENS: Dict[str, float] = {
     "gpt-4.1": 0.4,
-    "gemini-3.5": 0.2,
+    config.GEMINI_MODEL_DEFAULT: 0.2,
 }
 KETTLE_WH: int = 360
 

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -427,7 +427,7 @@ class CompanyHouseDocumentPipeline:
                     summary_text, _, _ = gemini_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_name=config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-3.5" # type: ignore
+                        model_name=config.GEMINI_MODEL_DEFAULT
                     )
                 elif openai and openai_key_present: 
                     logger.info(f"Summarizing {len(texts_for_year)} docs for {self.company_number} (Year {year}) using OpenAI.")
@@ -591,7 +591,7 @@ def run_batch_company_analysis(
                 openai_key_ok = openai and hasattr(config, 'OPENAI_API_KEY') and config.OPENAI_API_KEY  # type: ignore
 
                 if gemini_key_ok:
-                    ai_model_to_use_for_summary = config.GEMINI_MODEL_DEFAULT if hasattr(config, 'GEMINI_MODEL_DEFAULT') else "gemini-3.5"  # type: ignore
+                    ai_model_to_use_for_summary = config.GEMINI_MODEL_DEFAULT
                     summarizer_func_to_call = gemini_summarise_ch_docs
                     logger.debug(
                         f"Batch Run {run_id} ({company_no}): Using Gemini ('{ai_model_to_use_for_summary}') for CH summary."

--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ S3_TEXTRACT_BUCKET = os.getenv("S3_TEXTRACT_BUCKET") # For Textract
 
 # --- Model Configuration ---
 OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4.1")
-GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-3.5") # More specific name
+GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-1.5-flash-latest") # More specific name
 GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv("GEMINI_MODEL_FOR_PROTOCOL_CHECK", "gemini-1.5-flash-latest") # Model for protocol check
 
 # --- Application Constants ---


### PR DESCRIPTION
## Summary
- switch to `gemini-1.5-flash-latest` for summaries
- reference `GEMINI_MODEL_DEFAULT` in pricing and energy mappings
- use `GEMINI_MODEL_DEFAULT` directly in `ch_pipeline`

## Testing
- `python -m py_compile $(git ls-files '*.py')`