### PR TITLE
Handle Gemini model NotFound

### DIFF
--- a/ai_utils.py
+++ b/ai_utils.py
@@ -318,13 +318,14 @@ def gemini_summarise_ch_docs(
         return "Error: Google Generative AI SDK not installed.", 0, 0
 
     current_model_name = model_name or GEMINI_MODEL_DEFAULT
-    gemini_model_client = get_gemini_model(current_model_name)
+    gemini_model_client, init_error = get_gemini_model(current_model_name)
     total_prompt_tokens = 0
     total_completion_tokens = 0
 
     if not gemini_model_client:
-        logger.error(f"Could not initialize Gemini model '{current_model_name}' for CH summarization.")
-        return f"Error: Could not initialize Gemini model '{current_model_name}'.", 0, 0
+        err_msg = init_error or f"Could not initialize Gemini model '{current_model_name}'."
+        logger.error(err_msg)
+        return f"Error: {err_msg}", 0, 0
     
     stripped_text = text_to_summarize.strip()
     if not stripped_text:
@@ -435,11 +436,12 @@ def get_improved_prompt(
         return "Error: Google Generative AI SDK not installed. Cannot improve prompt."
 
     # Use the general purpose Gemini model for this, or a specific one if desired.
-    current_model_name = model_name or GEMINI_MODEL_DEFAULT 
-    gemini_model_client = get_gemini_model(current_model_name)
+    current_model_name = model_name or GEMINI_MODEL_DEFAULT
+    gemini_model_client, init_error = get_gemini_model(current_model_name)
 
     if not gemini_model_client:
-        return f"Error: Could not initialize Gemini model '{current_model_name}' for prompt improvement."
+        err_msg = init_error or f"Could not initialize Gemini model '{current_model_name}' for prompt improvement."
+        return f"Error: {err_msg}"
     if not original_prompt or not original_prompt.strip():
         return original_prompt 
 
@@ -506,10 +508,11 @@ def check_protocol_compliance(
         return "Error: Google Generative AI SDK not installed. Cannot check protocol compliance.", 0, 0
 
     current_model_name = model_name or GEMINI_MODEL_FOR_PROTOCOL_CHECK
-    gemini_model_client = get_gemini_model(current_model_name)
+    gemini_model_client, init_error = get_gemini_model(current_model_name)
 
     if not gemini_model_client:
-        return f"Error: Could not initialize Gemini model '{current_model_name}' for protocol compliance check.", 0, 0
+        err_msg = init_error or f"Could not initialize Gemini model '{current_model_name}' for protocol compliance check."
+        return f"Error: {err_msg}", 0, 0
 
     if not ai_text_output or not ai_text_output.strip():
         return "Error: No AI text provided for compliance check.", 0, 0

--- a/app.py
+++ b/app.py
@@ -506,7 +506,8 @@ with st.sidebar:
                         resp = client.chat.completions.create(model=current_ai_model_for_digest, temperature=0.1, max_tokens=3000, messages=[{"role": "system", "content": PROTO_TEXT}, {"role": "user", "content": update_digest_prompt}])
                         updated_digest_text = resp.choices[0].message.content.strip()
                     elif current_ai_model_for_digest.startswith("gemini-"):
-                        client = config.get_gemini_model(current_ai_model_for_digest); assert client and config.genai # Check config.genai
+                        client, init_error = config.get_gemini_model(current_ai_model_for_digest)
+                        assert client and config.genai, init_error
                         full_prompt_gemini = f"{PROTO_TEXT}\n\n{update_digest_prompt}" # Combine for Gemini
                         resp = client.generate_content(full_prompt_gemini, generation_config=config.genai.types.GenerationConfig(temperature=0.1, max_output_tokens=3000)) # Use config.genai
                         updated_digest_text = resp.text.strip() # Check for block reason
@@ -659,7 +660,8 @@ with tab_consult:
                             prompt_tokens = ai_api_response.usage.prompt_tokens
                             completion_tokens = ai_api_response.usage.completion_tokens
                     elif consult_model_name.startswith("gemini-"):
-                        gemini_model_client = config.get_gemini_model(consult_model_name); assert gemini_model_client and config.genai
+                        gemini_model_client, init_error = config.get_gemini_model(consult_model_name)
+                        assert gemini_model_client and config.genai, init_error
                         try: 
                             full_prompt_str_gemini = "\n\n".join([f"{m['role']}: {m['content']}" for m in messages_for_ai])
                             count_resp_prompt = gemini_model_client.count_tokens(full_prompt_str_gemini)


### PR DESCRIPTION
## Summary
- import `google.api_core.exceptions` in config
- return `(model, error)` from `get_gemini_model`
- propagate init errors to callers in ai_utils and app

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m py_compile config.py ai_utils.py app.py`