### PR TITLE
Fix deprecated streamlit rerun call

### DIFF
--- a/app.py
+++ b/app.py
@@ -491,7 +491,7 @@ with st.sidebar:
     # Trigger rerun safely after Context Injection expander
     if st.session_state.rerun_needed:
         st.session_state.rerun_needed = False
-        st.experimental_rerun()
+        st.rerun()
 
     st.markdown("---")
     if st.button("End Session & Update Digest", key="end_session_button_sidebar"):
@@ -806,7 +806,7 @@ with tab_consult:
     # Trigger rerun safely after Consult tab interactions
     if st.session_state.rerun_needed:
         st.session_state.rerun_needed = False
-        st.experimental_rerun()
+        st.rerun()
 
 with tab_ch_analysis:
     st.markdown("### Companies House Document Analysis")


### PR DESCRIPTION
## Summary
- use `st.rerun()` instead of `st.experimental_rerun()` in two places

## Testing
- `python -m unittest discover`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*