### PR TITLE
Enable OCR fallback for all PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Other optional variables (such as logging level or API retry options) can be def
 
 Within the **Group Structure** tab of the application there is a checkbox labelled **"Use AWS Textract for PDF OCR"**. When checked, the system attempts to initialise AWS Textract using the credentials above. Scanned or image-based PDFs from Companies House will then be sent to Textract for optical character recognition before analysis.
 
+If pdfminer extracts little or no text from a PDF, the system now automatically falls back to Textract whenever it is enabled. This means even filings that aren't explicitly flagged for OCR will still be processed when embedded text is missing.
+
 Textract calls can now run in parallel to speed up large batches. The default maximum number of concurrent OCR workers is controlled by the `MAX_TEXTRACT_WORKERS` environment variable (default `4`). Reduce this value if you hit AWS rate limits.
 
 Without OCR, many Companies House PDF filings cannot be parsed, meaning group-structure analysis may miss critical information contained in scanned documents. If OCR fails to initialise or the checkbox is left unchecked, only PDFs containing embedded text are analysed.

--- a/group_structure_utils.py
+++ b/group_structure_utils.py
@@ -159,22 +159,39 @@ def _parse_document_content(
     
     if content_to_parse is None and 'pdf' in doc_content_data and doc_content_data['pdf'] is not None:
         content_to_parse, content_type_to_parse = doc_content_data['pdf'], 'pdf'
-        if is_priority_for_ocr and ocr_handler:
-            logger.info(f"GS Parse: PDF '{doc_metadata.get('description')}' prioritized for OCR if needed.")
-        elif ocr_handler:
-            logger.info(f"GS Parse: PDF '{doc_metadata.get('description')}' will be parsed; OCR not priority for this stage.")
+        if ocr_handler:
+            if is_priority_for_ocr:
+                logger.info(
+                    f"GS Parse: PDF '{doc_metadata.get('description')}' prioritized for OCR if needed."
+                )
+            else:
+                logger.info(
+                    f"GS Parse: PDF '{doc_metadata.get('description')}' will be parsed; OCR available if needed."
+                )
         else:
-            logger.info(f"GS Parse: PDF '{doc_metadata.get('description')}' will be parsed without OCR handler.")
+            logger.info(
+                f"GS Parse: PDF '{doc_metadata.get('description')}' will be parsed without OCR handler."
+            )
 
     if content_to_parse is not None and content_type_to_parse is not None:
         parsed_result["source_format_parsed"] = content_type_to_parse.upper()
         try:
-            actual_ocr_handler_for_call = ocr_handler if (content_type_to_parse == 'pdf' and is_priority_for_ocr) else None
+            actual_ocr_handler_for_call = (
+                ocr_handler if (content_type_to_parse == 'pdf' and ocr_handler) else None
+            )
             extracted_text, pages_processed, extraction_error = extract_text_from_document(
                 content_to_parse, content_type_to_parse, company_no, actual_ocr_handler_for_call
             )
             if content_type_to_parse == 'pdf' and actual_ocr_handler_for_call and pages_processed > 0:
                 parsed_result["pages_ocrd"] = pages_processed
+                if is_priority_for_ocr:
+                    logger.info(
+                        f"OCR executed for prioritized PDF '{doc_metadata.get('description')}'."
+                    )
+                else:
+                    logger.info(
+                        f"OCR triggered for '{doc_metadata.get('description')}' due to low or no text."
+                    )
             if extraction_error: parsed_result["extraction_error"] = str(extraction_error)
             elif not extracted_text: parsed_result["text_content"] = ""
             else:

--- a/test_parse_document_content.py
+++ b/test_parse_document_content.py
@@ -1,0 +1,30 @@
+import unittest
+import logging
+from unittest.mock import patch
+
+from group_structure_utils import _parse_document_content
+
+class TestParseDocumentContentOCR(unittest.TestCase):
+    def test_pdf_without_text_triggers_ocr_even_when_not_priority(self):
+        doc_content = {"pdf": b"dummy"}
+        fetched_types = ["pdf"]
+        metadata = {"description": "some filing", "date": "2023-01-01"}
+        company_no = "12345678"
+
+        def fake_ocr(pdf_bytes, log_id):
+            return "OCR TEXT", 1, None
+
+        def fake_extract(doc_content_input, content_type_input, company_no_for_logging, ocr_handler=None):
+            # Simulate no text extracted by pdfminer so OCR handler is called if provided
+            if content_type_input == "pdf" and ocr_handler:
+                return ocr_handler(doc_content_input, company_no_for_logging)
+            return "", 0, None
+
+        with patch("group_structure_utils.extract_text_from_document", side_effect=fake_extract):
+            result = _parse_document_content(doc_content, fetched_types, company_no, metadata, logging.getLogger("test"), fake_ocr, False)
+
+        self.assertEqual(result["text_content"], "OCR TEXT")
+        self.assertEqual(result["pages_ocrd"], 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adjust `group_structure_utils._parse_document_content` so OCR handler is passed for any PDF
- log when OCR runs due to low text or priority flag
- clarify OCR fallback behaviour in README
- cover new logic with unit test

## Testing
- `python -m unittest discover -v`