### PR TITLE
Enhance group accounts detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Without OCR, many Companies House PDF filings cannot be parsed, meaning group-st
 
 When subsidiaries are listed after analysis the application now aggregates entries from all retrieved years into a single deduplicated list. Previously only the most recent year's subsidiaries were shown.
 
+Companies House may label some group accounts filings as "legacy". The system now automatically highlights these documents when presenting the list of available filings.
+
 Refer back to this README whenever configuring a new environment or troubleshooting OCR setup.
 
 ## Citation Verification


### PR DESCRIPTION
## Summary
- flag legacy group accounts by updating `ACCOUNTS_PRIORITY_ORDER`
- use the priority list when recommending filings and prioritising OCR
- show more metadata when listing filings and mark the recommended one
- note in README that Companies House may tag group accounts as "legacy"

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*