### PR TITLE
Add evidence index and search

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ import ch_pipeline
 import app_utils
 from about_page import render_about_page # Changed from show_about_page
 from instructions_page import render_instructions_page
+from evidence_index_utils import EvidenceIndex
 try:
     import group_structure_utils
     GROUP_STRUCTURE_AVAILABLE = True
@@ -253,6 +254,8 @@ def init_session_state():
         ,"auto_protocol_compliance": True
         ,"citation_links_updated": False
         ,"last_citations_found": []
+        ,"evidence_index": None
+        ,"evidence_last_results": []
         # Note: "company_group_analysis_results" and "company_group_ultimate_parent_cn"
         # from the original init did not have direct equivalents in the UI's init block.
         # If they are needed elsewhere, ensure they are handled consistently or add them here
@@ -580,18 +583,20 @@ st.markdown(f"## 🏛️ Strategic Counsel: {st.session_state.current_topic}")
 
 # Define tabs based on what functionality is available
 if 'GROUP_STRUCTURE_AVAILABLE' in globals() and GROUP_STRUCTURE_AVAILABLE:
-    tab_consult, tab_ch_analysis, tab_group_structure, tab_about_rendered, tab_instructions = st.tabs([
+    tab_consult, tab_ch_analysis, tab_evidence_index, tab_group_structure, tab_about_rendered, tab_instructions = st.tabs([
         "💬 Consult Counsel",
         "🇬🇧 Companies House Analysis",
-        "🕸️ Company Group Structure",  # Include group structure tab
+        "🔍 Evidence Index",
+        "🕸️ Company Group Structure",
         "ℹ️ About",
         "📖 Instructions"
     ])
 else:
-    # Fall back to three tabs if group structure not available
-    tab_consult, tab_ch_analysis, tab_about_rendered, tab_instructions = st.tabs([
+    # Fall back to four tabs if group structure not available
+    tab_consult, tab_ch_analysis, tab_evidence_index, tab_about_rendered, tab_instructions = st.tabs([
         "💬 Consult Counsel",
         "🇬🇧 Companies House Analysis",
+        "🔍 Evidence Index",
         "ℹ️ About",
         "📖 Instructions"
     ])
@@ -1214,6 +1219,52 @@ with tab_ch_analysis:
         if "total_cost_gbp" in metrics_data:
              cost_display = f"£{metrics_data.get('total_cost_gbp', 0.0)::.4f}"
         m_col3.metric("Est. Cost", cost_display)
+
+with tab_evidence_index:
+    st.markdown("### Evidence Index")
+    if st.session_state.evidence_index is None:
+        st.session_state.evidence_index = EvidenceIndex(APP_BASE_PATH / "evidence_index")
+    ei = st.session_state.evidence_index
+
+    st.markdown("#### Add Documents")
+    uploaded = st.file_uploader(
+        "Upload evidence files", ["pdf", "docx", "txt"], accept_multiple_files=True, key="evidence_upload_widget"
+    )
+    doc_type = st.text_input("Document Type", key="evidence_doc_type_input")
+    tags_input = st.text_input("Relevance Tags (comma-separated)", key="evidence_tags_input")
+    if st.button("Ingest to Index"):
+        if uploaded:
+            for f in uploaded:
+                tags = [t.strip() for t in tags_input.split(",") if t.strip()]
+                ei.ingest_uploaded_file(f, doc_type, tags)
+            st.success(f"Ingested {len(uploaded)} document(s) into index.")
+        else:
+            st.info("Upload files to ingest.")
+
+    st.markdown("---")
+    st.markdown("#### Search")
+    query = st.text_input("Search query", key="evidence_search_query")
+    type_options = sorted({m.get('doc_type') for m in ei.metadata})
+    tag_options = sorted({tag for m in ei.metadata for tag in m.get('tags', [])})
+    selected_type = st.selectbox("Filter by type", [""] + type_options, key="evidence_type_filter")
+    selected_tags = st.multiselect("Filter by tags", tag_options, key="evidence_tags_filter")
+    if st.button("Search Evidence"):
+        st.session_state.evidence_last_results = ei.search(
+            query,
+            top_k=10,
+            doc_type=selected_type or None,
+            tags=selected_tags or None,
+        )
+    results = st.session_state.get("evidence_last_results", [])
+    for score, meta in results:
+        st.subheader(meta.get("title"))
+        st.caption(f"Type: {meta.get('doc_type')} | Tags: {', '.join(meta.get('tags', []))}")
+        st.write(meta.get("summary"))
+        try:
+            with open(meta.get("path"), "rb") as fp:
+                st.download_button("View Document", fp, meta.get("file_name"))
+        except Exception:
+            st.warning("Document file missing")
 
 # --- START: REVISED TAB FOR GROUP STRUCTURE VISUALIZATION ---
 with tab_group_structure:

--- a/evidence_index_utils.py
+++ b/evidence_index_utils.py
@@ -1,0 +1,131 @@
+# evidence_index_utils.py
+"""Utilities for ingesting evidence documents and performing semantic search."""
+
+from __future__ import annotations
+
+import json
+import io
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+
+import numpy as np
+
+try:
+    import faiss
+except ImportError:  # pragma: no cover - handled at runtime
+    faiss = None  # type: ignore
+
+from config import logger, get_openai_client
+import app_utils
+
+EMBED_MODEL = "text-embedding-3-small"
+EMBED_DIM = 1536
+
+class EvidenceIndex:
+    """Simple FAISS-backed evidence index."""
+
+    def __init__(self, dir_path: str | Path):
+        self.dir_path = Path(dir_path)
+        self.index_file = self.dir_path / "faiss.index"
+        self.meta_file = self.dir_path / "metadata.json"
+        self.docs_dir = self.dir_path / "docs"
+        self.dir_path.mkdir(parents=True, exist_ok=True)
+        self.docs_dir.mkdir(exist_ok=True)
+        self.metadata: List[Dict] = []
+        self.index = None
+        self._load()
+
+    def _load(self) -> None:
+        if faiss is None:
+            logger.error("faiss library not available. Evidence index disabled.")
+            self.index = None
+            self.metadata = []
+            return
+        if self.index_file.exists():
+            try:
+                self.index = faiss.read_index(str(self.index_file))
+            except Exception as e:
+                logger.error(f"Failed to load FAISS index: {e}")
+                self.index = faiss.IndexFlatL2(EMBED_DIM)
+        else:
+            self.index = faiss.IndexFlatL2(EMBED_DIM)
+        if self.meta_file.exists():
+            try:
+                self.metadata = json.loads(self.meta_file.read_text())
+            except Exception as e:
+                logger.error(f"Failed to load metadata: {e}")
+                self.metadata = []
+
+    def _save(self) -> None:
+        if self.index is None:
+            return
+        try:
+            faiss.write_index(self.index, str(self.index_file))
+            self.meta_file.write_text(json.dumps(self.metadata, indent=2))
+        except Exception as e:
+            logger.error(f"Error saving evidence index: {e}")
+
+    def _embed(self, text: str) -> np.ndarray:
+        client = get_openai_client()
+        if client is None:
+            raise RuntimeError("OpenAI client not available for embeddings")
+        resp = client.embeddings.create(model=EMBED_MODEL, input=[text])
+        vec = np.asarray(resp.data[0].embedding, dtype="float32")
+        return vec
+
+    def ingest_uploaded_file(
+        self,
+        uploaded_file,
+        doc_type: str,
+        tags: List[str] | None = None,
+    ) -> Dict:
+        """Extract text, summarise and index an uploaded file."""
+        if faiss is None:
+            raise RuntimeError("faiss library not available")
+        tags = tags or []
+        file_bytes = uploaded_file.getvalue()
+        text, err = app_utils.extract_text_from_uploaded_file(io.BytesIO(file_bytes), uploaded_file.name)
+        if err:
+            logger.warning(f"{uploaded_file.name}: {err}")
+        if not text:
+            text = "No extractable text."
+        title, summary = app_utils.summarise_with_title(text, "", uploaded_file.name)
+        embedding = self._embed(summary)
+        self.index.add(np.expand_dims(embedding, 0))
+        doc_path = self.docs_dir / uploaded_file.name
+        try:
+            doc_path.write_bytes(file_bytes)
+        except Exception as e:
+            logger.error(f"Failed to save uploaded file {uploaded_file.name}: {e}")
+        meta = {
+            "path": str(doc_path),
+            "file_name": uploaded_file.name,
+            "doc_type": doc_type,
+            "tags": tags,
+            "title": title,
+            "summary": summary,
+        }
+        self.metadata.append(meta)
+        self._save()
+        return meta
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        doc_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> List[Tuple[float, Dict]]:
+        if faiss is None or self.index is None or self.index.ntotal == 0:
+            return []
+        embedding = self._embed(query)
+        distances, indices = self.index.search(np.expand_dims(embedding, 0), min(top_k, self.index.ntotal))
+        results: List[Tuple[float, Dict]] = []
+        for dist, idx in zip(distances[0], indices[0]):
+            meta = self.metadata[idx]
+            if doc_type and meta.get("doc_type") != doc_type:
+                continue
+            if tags and not set(tags).issubset(set(meta.get("tags", []))):
+                continue
+            results.append((dist, meta))
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ openai
 google-generativeai
 boto3 # Includes botocore
 python-dotenv
+
+numpy
+faiss-cpu
+


### PR DESCRIPTION
## Summary
- add `evidence_index_utils` module to manage a FAISS backed evidence index
- allow uploading documents, storing embeddings and metadata
- include numpy and faiss in requirements
- expose new *Evidence Index* tab in the app with upload and search UI

## Testing
- `python -m py_compile evidence_index_utils.py app.py`
- `python -m pytest -q` *(fails: No module named pytest)*