### PR TITLE
Add evidence index tab alongside case timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Companies House may label some group accounts filings as "legacy". The system no
 
 Refer back to this README whenever configuring a new environment or troubleshooting OCR setup.
 
+## Case Timeline
+
+The **📅 Case Timeline** tab lets you upload court docket files in CSV, JSON or PDF format. Dates and descriptions are extracted and displayed chronologically. Long descriptions are summarised using the same AI routines as the Companies House analysis. If the optional `streamlit_timeline` component is installed the events are shown on an interactive timeline, otherwise a simple table is displayed.
+
+## Evidence Index
+
+The **🔍 Evidence Index** tab allows you to upload supporting documents and store them with embeddings for semantic search. Provide a document type and relevance tags on upload, then search the index to retrieve summaries and download links.
+
 ## Citation Verification
 
 After each consultation the app scans the AI response for case names and statute titles. It then checks any uploaded documents for matching text and falls back to searching trusted public sources such as Bailii or Casemine. Citations that cannot be located are tagged with `[UNVERIFIED]` and a warning is shown asking you to provide the original document or a direct link. A form appears letting you enter a URL or reference for each citation and these links are stored in `verified_sources.json` for later checking. Verified citations are cached in the same file to speed up later runs.

--- a/evidence_index_utils.py
+++ b/evidence_index_utils.py
@@ -1,0 +1,131 @@
+# evidence_index_utils.py
+"""Utilities for ingesting evidence documents and performing semantic search."""
+
+from __future__ import annotations
+
+import json
+import io
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+
+import numpy as np
+
+try:
+    import faiss
+except ImportError:  # pragma: no cover - handled at runtime
+    faiss = None  # type: ignore
+
+from config import logger, get_openai_client
+import app_utils
+
+EMBED_MODEL = "text-embedding-3-small"
+EMBED_DIM = 1536
+
+class EvidenceIndex:
+    """Simple FAISS-backed evidence index."""
+
+    def __init__(self, dir_path: str | Path):
+        self.dir_path = Path(dir_path)
+        self.index_file = self.dir_path / "faiss.index"
+        self.meta_file = self.dir_path / "metadata.json"
+        self.docs_dir = self.dir_path / "docs"
+        self.dir_path.mkdir(parents=True, exist_ok=True)
+        self.docs_dir.mkdir(exist_ok=True)
+        self.metadata: List[Dict] = []
+        self.index = None
+        self._load()
+
+    def _load(self) -> None:
+        if faiss is None:
+            logger.error("faiss library not available. Evidence index disabled.")
+            self.index = None
+            self.metadata = []
+            return
+        if self.index_file.exists():
+            try:
+                self.index = faiss.read_index(str(self.index_file))
+            except Exception as e:
+                logger.error(f"Failed to load FAISS index: {e}")
+                self.index = faiss.IndexFlatL2(EMBED_DIM)
+        else:
+            self.index = faiss.IndexFlatL2(EMBED_DIM)
+        if self.meta_file.exists():
+            try:
+                self.metadata = json.loads(self.meta_file.read_text())
+            except Exception as e:
+                logger.error(f"Failed to load metadata: {e}")
+                self.metadata = []
+
+    def _save(self) -> None:
+        if self.index is None:
+            return
+        try:
+            faiss.write_index(self.index, str(self.index_file))
+            self.meta_file.write_text(json.dumps(self.metadata, indent=2))
+        except Exception as e:
+            logger.error(f"Error saving evidence index: {e}")
+
+    def _embed(self, text: str) -> np.ndarray:
+        client = get_openai_client()
+        if client is None:
+            raise RuntimeError("OpenAI client not available for embeddings")
+        resp = client.embeddings.create(model=EMBED_MODEL, input=[text])
+        vec = np.asarray(resp.data[0].embedding, dtype="float32")
+        return vec
+
+    def ingest_uploaded_file(
+        self,
+        uploaded_file,
+        doc_type: str,
+        tags: List[str] | None = None,
+    ) -> Dict:
+        """Extract text, summarise and index an uploaded file."""
+        if faiss is None:
+            raise RuntimeError("faiss library not available")
+        tags = tags or []
+        file_bytes = uploaded_file.getvalue()
+        text, err = app_utils.extract_text_from_uploaded_file(io.BytesIO(file_bytes), uploaded_file.name)
+        if err:
+            logger.warning(f"{uploaded_file.name}: {err}")
+        if not text:
+            text = "No extractable text."
+        title, summary = app_utils.summarise_with_title(text, "", uploaded_file.name)
+        embedding = self._embed(summary)
+        self.index.add(np.expand_dims(embedding, 0))
+        doc_path = self.docs_dir / uploaded_file.name
+        try:
+            doc_path.write_bytes(file_bytes)
+        except Exception as e:
+            logger.error(f"Failed to save uploaded file {uploaded_file.name}: {e}")
+        meta = {
+            "path": str(doc_path),
+            "file_name": uploaded_file.name,
+            "doc_type": doc_type,
+            "tags": tags,
+            "title": title,
+            "summary": summary,
+        }
+        self.metadata.append(meta)
+        self._save()
+        return meta
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        doc_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> List[Tuple[float, Dict]]:
+        if faiss is None or self.index is None or self.index.ntotal == 0:
+            return []
+        embedding = self._embed(query)
+        distances, indices = self.index.search(np.expand_dims(embedding, 0), min(top_k, self.index.ntotal))
+        results: List[Tuple[float, Dict]] = []
+        for dist, idx in zip(distances[0], indices[0]):
+            meta = self.metadata[idx]
+            if doc_type and meta.get("doc_type") != doc_type:
+                continue
+            if tags and not set(tags).issubset(set(meta.get("tags", []))):
+                continue
+            results.append((dist, meta))
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,8 @@ openai
 google-generativeai
 boto3 # Includes botocore
 python-dotenv
+streamlit-timeline
+
+numpy
+faiss-cpu
+

--- a/timeline_utils.py
+++ b/timeline_utils.py
@@ -1,0 +1,114 @@
+import json
+import logging
+import re
+from pathlib import Path
+from typing import List, Dict, Union
+
+import pandas as pd
+from dateutil import parser as dateparser
+
+from text_extraction_utils import pdfminer_extract
+from ai_utils import (
+    MIN_CHARS_FOR_AI_SUMMARY,
+    gpt_summarise_ch_docs,
+    gemini_summarise_ch_docs,
+)
+
+logger = logging.getLogger(__name__)
+
+Event = Dict[str, str]
+
+
+def _parse_date(date_str: str) -> str:
+    """Return ISO formatted date string if parsable, else empty string."""
+    if not date_str:
+        return ""
+    try:
+        dt = dateparser.parse(date_str, dayfirst=True, fuzzy=True)
+        if dt:
+            return dt.date().isoformat()
+    except Exception:
+        pass
+    return ""
+
+
+def _summarise_if_long(text: str) -> str:
+    """Use AI summarisation for long descriptions."""
+    if not text or len(text) < MIN_CHARS_FOR_AI_SUMMARY:
+        return text.strip() if text else ""
+
+    try:
+        summary, _, _ = gemini_summarise_ch_docs(text, "docket_event")
+        if summary and not summary.lower().startswith("error"):
+            return summary.strip()
+    except Exception as e:
+        logger.warning("Gemini summarisation failed: %s", e)
+
+    try:
+        summary, _, _ = gpt_summarise_ch_docs(text, "docket_event")
+        if summary and not summary.lower().startswith("error"):
+            return summary.strip()
+    except Exception as e:
+        logger.warning("GPT summarisation failed: %s", e)
+    return text.strip()
+
+
+def parse_csv(path: Path) -> List[Event]:
+    df = pd.read_csv(path)
+    cols_lower = {c.lower(): c for c in df.columns}
+    date_col = next((cols_lower[c] for c in cols_lower if "date" in c), df.columns[0])
+    desc_col = next(
+        (cols_lower[c] for c in cols_lower if any(word in c for word in ["description", "event", "entry", "detail"])),
+        df.columns[1] if len(df.columns) > 1 else df.columns[0],
+    )
+    events: List[Event] = []
+    for _, row in df.iterrows():
+        date_val = _parse_date(str(row.get(date_col, "")))
+        desc = str(row.get(desc_col, "")).strip()
+        events.append({"date": date_val, "description": _summarise_if_long(desc)})
+    return events
+
+
+def parse_json(path: Path) -> List[Event]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if isinstance(data, dict):
+        data = data.get("events") or list(data.values())
+
+    events: List[Event] = []
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                date_val = _parse_date(str(item.get("date") or item.get("event_date") or ""))
+                desc = str(item.get("description") or item.get("event") or item.get("detail") or item)
+                events.append({"date": date_val, "description": _summarise_if_long(desc)})
+    return events
+
+
+def parse_pdf(path: Path) -> List[Event]:
+    text = pdfminer_extract(str(path))
+    events: List[Event] = []
+    date_re = re.compile(r"(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{4}-\d{2}-\d{2})")
+    for line in text.splitlines():
+        m = date_re.search(line)
+        if m:
+            date_val = _parse_date(m.group(1))
+            desc = line[m.end():].strip() or line.strip()
+            events.append({"date": date_val, "description": _summarise_if_long(desc)})
+    return events
+
+
+def parse_docket_file(file_path: Union[str, Path]) -> List[Event]:
+    """Parse a docket CSV, JSON or PDF file into a list of events."""
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    ext = path.suffix.lower()
+    if ext == ".csv":
+        return parse_csv(path)
+    if ext == ".json":
+        return parse_json(path)
+    if ext == ".pdf":
+        return parse_pdf(path)
+    raise ValueError(f"Unsupported docket file type: {ext}")


### PR DESCRIPTION
## Summary
- restore case timeline module and tab after merging with evidence index work
- keep timeline import and dependencies
- include new evidence index functionality alongside timeline
- update README with Case Timeline and Evidence Index sections
- add numpy and faiss dependencies after streamlit-timeline

## Testing
- `python -m py_compile evidence_index_utils.py timeline_utils.py app.py`
- `python -m pytest -q` *(fails: No module named pytest)*