### PR TITLE
Add OpenAI model check helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The application loads configuration from a `.env` file or the host environment. 
 - `GEMINI_API_KEY` – API key for Google Gemini models.
 - `GEMINI_MODEL_FOR_SUMMARIES` – override the Gemini model used for summaries (default `gemini-1.5-flash-latest`).
 - `OPENAI_MODEL` – default OpenAI model for analysis tasks and fallback summaries.
+-   If you encounter errors when using a newer model name like `gpt-4.1`, run
+    the helper `check_openai_model()` from `config.py` or `openai.models.list()`
+    to verify the model is available to your API key.
 - `GEMINI_MODEL_FOR_PROTOCOL_CHECK` – Gemini model used when checking responses against the strategic protocols.
 - `PROTOCOL_CHECK_MODEL_PROVIDER` – choose `gemini` (default) or `openai` for protocol compliance checks.
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials used when AWS Textract OCR is enabled.

--- a/config.py
+++ b/config.py
@@ -164,6 +164,26 @@ def get_openai_client() -> Optional[openai.OpenAI]:
             _openai_client = None
     return _openai_client
 
+
+def check_openai_model(model_name: str) -> Tuple[bool, str]:
+    """Verify that the requested OpenAI model can be retrieved."""
+    client = get_openai_client()
+    if not client:
+        msg = "OpenAI client not available."
+        logger.error(msg)
+        return False, msg
+
+    try:
+        client.models.retrieve(model_name)
+        logger.info(f"OpenAI model '{model_name}' is available.")
+        return True, ""
+    except Exception as e:
+        msg = (
+            f"Model '{model_name}' not found; check OPENAI_MODEL or run client.models.list()"
+        )
+        logger.error(msg)
+        return False, msg
+
 def get_ch_session(api_key_override: Optional[str] = None) -> requests.Session:
     """
     Returns a Companies House API session.


### PR DESCRIPTION
## Summary
- add `check_openai_model` helper to verify availability of a model name
- document how to verify new OpenAI models in README

## Testing
- `pytest -q` *(fails: command not found)*