### PR TITLE
Fix prompt improvement and model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The application loads configuration from a `.env` file or the host environment. 
 - `OPENAI_API_KEY` – API key for GPT models (used for summarisation and drafting).
 - `GEMINI_API_KEY` – API key for Google Gemini models.
 - `GEMINI_MODEL_FOR_SUMMARIES` – override the Gemini model used for summaries (default `gemini-1.5-flash-latest`).
-- `OPENAI_MODEL` – default OpenAI model for analysis tasks and fallback summaries.
+- `OPENAI_MODEL` – default OpenAI model for analysis tasks and fallback summaries (defaults to `gpt-4o`).
 - `GEMINI_MODEL_FOR_PROTOCOL_CHECK` – Gemini model used when checking responses against the strategic protocols.
 - `PROTOCOL_CHECK_MODEL_PROVIDER` – choose `gemini` (default) or `openai` for protocol compliance checks.
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials used when AWS Textract OCR is enabled.
@@ -31,6 +31,8 @@ The application loads configuration from a `.env` file or the host environment. 
 Gemini is the preferred model for generating summaries. If an OpenAI API key is provided, GPT models are used for analysis tasks and can power protocol checks when `PROTOCOL_CHECK_MODEL_PROVIDER` is set to `openai`.
 
 Other optional variables (such as logging level or API retry options) can be defined as needed. See `config.py` for the full list.
+
+If you try a new OpenAI model and requests fail, call `check_openai_model("<model>")` to confirm availability or run `openai.models.list()` to inspect your accessible models.
 
 ## Enabling OCR with AWS Textract
 

--- a/app.py
+++ b/app.py
@@ -179,11 +179,15 @@ for rel_p in REQUIRED_DIRS_REL:
     except OSError as e_mkdir: st.error(f"Fatal Error creating directory {abs_p.name}: {e_mkdir}"); st.stop()
 
 MODEL_PRICES_PER_1K_TOKENS_GBP: Dict[str, float] = {
-    "gpt-4.1": 0.0080,
+    "gpt-4o": 0.0050,
+    config.OPENAI_MODEL_DEFAULT: 0.0050,
+    "gemini-1.5-flash-latest": 0.0028,
     config.GEMINI_MODEL_DEFAULT: 0.0028,
 }
 MODEL_ENERGY_WH_PER_1K_TOKENS: Dict[str, float] = {
-    "gpt-4.1": 0.4,
+    "gpt-4o": 0.4,
+    config.OPENAI_MODEL_DEFAULT: 0.4,
+    "gemini-1.5-flash-latest": 0.2,
     config.GEMINI_MODEL_DEFAULT: 0.2,
 }
 KETTLE_WH: int = 360
@@ -231,7 +235,7 @@ def init_session_state():
         "latest_digest_content": "",
         "document_processing_complete": True, "ch_last_digest_path": None, "ch_last_df": None,
         "ch_last_narrative": None, "ch_last_batch_metrics": {},
-        "consult_digest_model": config.OPENAI_MODEL_DEFAULT if 'config' in globals() and hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1", # Fallback if config not loaded
+        "consult_digest_model": config.OPENAI_MODEL_DEFAULT if 'config' in globals() and hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o", # Fallback if config not loaded
         "ch_analysis_summaries_for_injection": [], # List of (company_id, title_for_list, summary_text)
         
         # For "Improve Prompt" in Consult Counsel

--- a/ch_pipeline.py
+++ b/ch_pipeline.py
@@ -442,7 +442,7 @@ class CompanyHouseDocumentPipeline:
                     summary_text, _, _ = gpt_summarise_ch_docs(
                         text_to_summarize=combined_text_for_year, company_no=f"{self.company_number}_Year_{year}",
                         specific_instructions=f"Summarize key events, financial trends, governance changes for {self.company_number} in {year}.",
-                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1" # type: ignore
+                        model_to_use=config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o" # type: ignore
                     )
                 else:
                     logger.warning(f"No AI summarization client (Gemini/OpenAI) available/configured for {self.company_number} (Year {year}).")
@@ -612,7 +612,7 @@ def run_batch_company_analysis(
                         f"Batch Run {run_id} ({company_no}): Using Gemini ('{ai_model_to_use_for_summary}') for CH summary."
                     )
                 elif openai_key_ok:
-                    ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4.1"  # type: ignore
+                    ai_model_to_use_for_summary = config.OPENAI_MODEL_DEFAULT if hasattr(config, 'OPENAI_MODEL_DEFAULT') else "gpt-4o"  # type: ignore
                     summarizer_func_to_call = gpt_summarise_ch_docs
                     logger.debug(
                         f"Batch Run {run_id} ({company_no}): Using OpenAI ('{ai_model_to_use_for_summary}') for CH summary (Gemini unavailable)."

--- a/config.py
+++ b/config.py
@@ -61,7 +61,7 @@ AWS_REGION_DEFAULT = os.getenv("AWS_DEFAULT_REGION", "eu-west-2")
 S3_TEXTRACT_BUCKET = os.getenv("S3_TEXTRACT_BUCKET") # For Textract
 
 # --- Model Configuration ---
-OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4.1")
+OPENAI_MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4o")
 GEMINI_MODEL_DEFAULT = os.getenv("GEMINI_MODEL_FOR_SUMMARIES", "gemini-1.5-flash-latest") # More specific name
 GEMINI_MODEL_FOR_PROTOCOL_CHECK = os.getenv("GEMINI_MODEL_FOR_PROTOCOL_CHECK", "gemini-1.5-flash-latest") # Model for protocol check
 PROTOCOL_CHECK_MODEL_PROVIDER = os.getenv("PROTOCOL_CHECK_MODEL_PROVIDER", "gemini")  # "gemini" or "openai"
@@ -163,6 +163,19 @@ def get_openai_client() -> Optional[openai.OpenAI]:
             logger.warning("OPENAI_API_KEY not found. OpenAI calls will fail.")
             _openai_client = None
     return _openai_client
+
+def check_openai_model(model_name: str) -> bool:
+    """Return ``True`` if the specified OpenAI model can be retrieved."""
+    client = get_openai_client()
+    if not client:
+        return False
+    try:
+        client.models.retrieve(model_name)
+        logger.info(f"OpenAI model '{model_name}' is available.")
+        return True
+    except Exception as e_model:
+        logger.error(f"OpenAI model '{model_name}' could not be retrieved: {e_model}")
+        return False
 
 def get_ch_session(api_key_override: Optional[str] = None) -> requests.Session:
     """

--- a/group_structure_utils.py
+++ b/group_structure_utils.py
@@ -22,7 +22,7 @@ except ImportError:
     def get_openai_client() -> Optional[object]:
         logger.warning("group_structure_utils: get_openai_client fallback used. OpenAI features unavailable.")
         return None
-    OPENAI_MODEL_DEFAULT = "gpt-4.1"
+    OPENAI_MODEL_DEFAULT = "gpt-4o"
 
 # --- Type Aliases ---
 JSONObj: TypeAlias = Dict[str, Any]


### PR DESCRIPTION
## Summary
- default to `gpt-4o` for OpenAI calls
- add `check_openai_model` helper
- ensure model list always includes Gemini 1.5 and GPT‑4o
- update fallback model strings across modules
- document new helper in README

## Testing
- `pytest -q` *(fails: pytest not installed)*