### PR TITLE
Add Drive integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The application loads configuration from a `.env` file or the host environment. 
 - `AWS_DEFAULT_REGION` – AWS region (for Textract), for example `eu-west-2`.
 - `S3_TEXTRACT_BUCKET` – S3 bucket name used to temporarily store PDFs when sending them to Textract.
 - `MAX_TEXTRACT_WORKERS` – number of concurrent Textract OCR workers (default `4`).
+- `ENABLE_DRIVE_IMPORT` – set to `true` to expose Google Drive integration.
+- `DRIVE_CLIENT_ID` and `DRIVE_CLIENT_SECRET` – OAuth credentials for Drive access.
 
 Gemini is the preferred model for generating summaries. If an OpenAI API key is provided, GPT models are used for analysis tasks and can power protocol checks when `PROTOCOL_CHECK_MODEL_PROVIDER` is set to `openai`.
 
@@ -49,10 +51,21 @@ Without OCR, many Companies House PDF filings cannot be parsed, meaning group-st
 
 When subsidiaries are listed after analysis the application now aggregates entries from all retrieved years into a single deduplicated list. Previously only the most recent year's subsidiaries were shown.
 
+
 Companies House may label some group accounts filings as "legacy". The system now automatically highlights these documents when presenting the list of available filings.
 
-
 Refer back to this README whenever configuring a new environment or troubleshooting OCR setup.
+
+## Importing Files from Google Drive
+
+When `ENABLE_DRIVE_IMPORT` is `true` the sidebar shows a **Drive Files** button. On first use it triggers an OAuth consent flow using `DRIVE_CLIENT_ID` and `DRIVE_CLIENT_SECRET`.
+
+1. Follow the link that appears and grant the app access to your Drive.
+2. Copy the verification code back into the text box and continue.
+3. A file picker lists your recent PDFs, DOCX or TXT files. Tick any you wish to load.
+4. Selected files are downloaded to `APPLICATION_SCRATCH_DIR` and processed exactly like standard uploads.
+
+Set `ENABLE_DRIVE_IMPORT` to `false` (default) to hide this option and prevent Drive OAuth prompts.
 
 ## Case Timeline
 

--- a/about_page.py
+++ b/about_page.py
@@ -77,6 +77,7 @@ def render_about_page():
         SC supports a versatile intake system to build the contextual basis for AI interaction:
         - **File Uploads:** Accepts PDF, DOCX, and TXT files. Documents are processed locally to extract textual content.
         - **URL Ingestion:** Users can paste URLs, and the application attempts to fetch and parse the primary textual content from web pages.
+        - **Drive Files (optional):** Authorise the app with Google OAuth to browse and select documents directly from your Drive.
         - **AI-Powered Summarization:** Extracted text is summarized using an AI model. These summaries can be:
             - Displayed for quick review.
             - Cached locally per topic to avoid re-processing.

--- a/instructions_page.py
+++ b/instructions_page.py
@@ -23,7 +23,10 @@ def render_instructions_page():
            - Tick summaries you want to inject back into **Consult Counsel**.
         4. **Company Group Structure** (if enabled):
            - Provide a company number and follow the step buttons to fetch profiles, parent data and subsidiary details.
-        5. **About** – Overview of the system and environment details.
+        5. **Drive Files** (if enabled):
+           - Click **Drive Files** in the sidebar to authorise access to your Google Drive.
+           - Select PDF, DOCX or TXT files to import. They will be processed like standard uploads.
+        6. **About** – Overview of the system and environment details.
         
         For best results keep instructions concise and load only the most relevant context.
         """


### PR DESCRIPTION
## Summary
- document environment variables for Drive OAuth
- document Drive OAuth setup and workflow
- mention Drive option in instructions and about pages

## Testing
- `pytest -q` *(fails: command not found)*