### PR TITLE
Ensure pytest installed via pinned requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ Please follow these conventions when contributing:
 
 ## Development
 - Use **Python 3.10+**.
-- Install dependencies with `pip install -r requirements.txt` if network
-  access is available.
+- Install dependencies with `pip install -r requirements.txt` while network
+  access is available. The file pins exact versions, including `pytest`, so
+  this step must happen before any network restrictions.
 - Unit tests are located in files starting with `test_`. Run them using:
   ```bash
   python -m unittest discover -v

--- a/README.md
+++ b/README.md
@@ -2,10 +2,17 @@
 
 ## Setup Overview
 
-1. **Install dependencies**
-   ```bash
-   pip install -r requirements.txt
-   ```
+1. **Install dependencies** *(while network is available)*
+ ```bash
+  pip install -r requirements.txt
+  ```
+  The requirements file pins exact versions for every package, including
+  `pytest`, so install them before network access is disabled.  Verify with:
+  ```bash
+  pytest --version
+  ```
+   You can also run `./setup.sh` to automatically create a virtual environment
+   and install the pinned dependencies.
 2. **Create a `.env` file** in the project root containing the required environment variables.
 3. **Run the application**
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,25 @@
 # Core Streamlit and web
-streamlit
-requests
-beautifulsoup4
+streamlit==1.33.0
+requests==2.31.0
+beautifulsoup4==4.12.3
 
 # Data handling
-pandas
-PyPDF2
-pdfminer.six
-python-docx # For importing docx
-openpyxl
+pandas==2.2.2
+PyPDF2==3.0.1
+pdfminer.six==20221105
+python-docx==1.1.0  # For importing docx
+openpyxl==3.1.2
 xmltodict==0.13.0
 
 # AI / cloud
-openai
-google-generativeai
-boto3 # Includes botocore
-python-dotenv
-streamlit-timeline
-google-api-python-client
-google-auth-oauthlib
-google-auth-httplib2
+openai==1.23.6
+google-generativeai==0.3.1
+boto3==1.34.130  # Includes botocore
+python-dotenv==1.0.1
+streamlit-timeline==0.1.3
+google-api-python-client==2.126.0
+google-auth-oauthlib==1.2.0
+google-auth-httplib2==0.2.0
 
 # Testing
-pytest
-
+pytest==7.4.4

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Simple setup script for Strategic Counsel Gen 3
+set -euo pipefail
+
+python3 -m venv venv
+source venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+# Optional test verification
+pytest --version >/dev/null 2>&1 && echo "pytest installed"


### PR DESCRIPTION
## Summary
- pin exact versions in `requirements.txt`
- clarify network-limited install steps in `README.md`
- update AGENTS guidelines about pinned requirements
- add `setup.sh` helper to create venv and install deps

## Testing
- `python -m unittest discover -v`