### PR TITLE
Fix logo sidebar display

### DIFF
--- a/app.py
+++ b/app.py
@@ -286,7 +286,7 @@ def init_session_state():
 init_session_state()
 
 with st.sidebar:
-    st.image(str(LOGO_PATH), use_container_width=False)
+    st.image(str(LOGO_PATH), use_column_width=False)
     st.markdown("## Configuration")
     current_topic_input = st.text_input("Matter / Topic ID", st.session_state.current_topic, key="topic_input_sidebar")
     if current_topic_input != st.session_state.current_topic:


### PR DESCRIPTION
## Summary
- correct use of Streamlit `st.image` parameter
- keep sidebar logo sizing consistent

## Testing
- `python -m unittest discover -v`